### PR TITLE
Refactor OvSW codebase for maintainability

### DIFF
--- a/args.py
+++ b/args.py
@@ -62,7 +62,7 @@ def parse_arguments():
     parser.add_argument("--score-init-constant", type=float, default=None, help="Sample Baseline Subnet Init")
 
     # Binary Network related
-    parser.add_argument("--forward-type", type=str, required=True, help="Binart type.")
+    parser.add_argument("--forward-type", type=str, required=True, help="Binary type.")
     parser.add_argument("--act-a", default="binary", type=str, help="Binary Func to activation.")
     parser.add_argument("--act-w", default="ste", type=str, help="Binary Func to weight.")
 

--- a/main.py
+++ b/main.py
@@ -1,10 +1,7 @@
 import copy
 import os
-import pathlib
-import random
 import time
 
-import numpy as np
 import torch
 import torch.nn as nn
 from ruamel import yaml
@@ -14,16 +11,19 @@ from torch.utils.tensorboard import SummaryWriter
 from utils.function import (
     get_dataset,
     get_directories,
-    get_model, get_optimizer,
+    get_model,
+    get_optimizer,
     get_trainer,
     pretrained,
     resume,
-    set_gpu
+    set_gpu,
 )
 from utils.logger import create_logger, prRed
 from utils.logging import AverageMeter, ProgressMeter
 from utils.net_utils import get_lr, get_parameters_num, init_model, save_checkpoint, update_epoch
+from utils.results import write_result_to_csv
 from utils.schedulers import get_policy
+from utils.seed import set_seed
 
 
 def main():
@@ -31,12 +31,7 @@ def main():
     print(args)
 
     if args.seed is not None:
-        os.environ['PYTHONHASHSEED'] = str(args.seed)
-        random.seed(args.seed)
-        np.random.seed(args.seed)
-        torch.manual_seed(args.seed)
-        torch.cuda.manual_seed(args.seed)
-        torch.cuda.manual_seed_all(args.seed)
+        set_seed(args.seed)
 
     # Simply call main_worker function
     if hasattr(args, "distributed") and args.distributed:
@@ -196,7 +191,7 @@ def main_worker(args):
         end_epoch = time.time()
 
     device_target = torch.cuda.get_device_name()
-    write_result_to_csv_scrach(
+    write_result_to_csv(
         arch=args.arch,
         set=args.set,
         base_config=args.config,
@@ -229,91 +224,8 @@ def main_worker(args):
         track_momentum=args.track_momentum,
         track_threshold=args.track_threshold,
         dampen_weight=args.dampen_weight,
-        enable_ags=args.enable_ags
+        enable_ags=args.enable_ags,
     )
-
-
-def write_result_to_csv_scrach(**kwargs):
-    results = pathlib.Path("runs") / f"train_{kwargs.get('arch')}_from_scrach.csv"
-
-    if not results.exists():
-        results.write_text(
-            "Date Finished, "
-            "Base Config, "
-            "Name, "
-            "Arch, "
-            "Set, "
-            "Current Val Top 1, "
-            "Current Val Top 5, "
-            "Best Val Top 1, "
-            "Best Val Top 5, "
-            "Best Train Top 1, "
-            "Best Train Top 5, "
-            "Device Target, "
-            "Epochs, "
-            "Optimizer, "
-            "Weight Decay, "
-            "Warmup Length, "
-            "Seed, "
-            "Forward Type, "
-            "Nesterov, "
-            "NoBnDecay, "
-            "Trainers, "
-            "LearningRate, "
-            "BatchSize, "
-            "ConvType, "
-            "BnType, "
-            "Nonlinearity, "
-            "ActActivation, "
-            "ActWeight, "
-            "Delta, "
-            "Enable Dampening, "
-            "Track Momentum, "
-            "Track Threshold, "
-            "Dampen Weight, "
-            "Enable Ags\n"
-        )
-
-    now = time.strftime("%m-%d-%y_%H:%M:%S")
-
-    with open(results, "a+") as f:
-        f.write(
-            ("{now}, "
-             "{base_config}, "
-             "{name}, "
-             "{arch}, "
-             "{set}, "
-             "{curr_acc1:.02f}, "
-             "{curr_acc5:.02f}, "
-             "{best_acc1:.02f}, "
-             "{best_acc5:.02f}, "
-             "{best_train_acc1:.02f}, "
-             "{best_train_acc5:.02f}, "
-             "{device_target}, "
-             "{epochs}, "
-             "{optimizer}, "
-             "{weight_decay}, "
-             "{warmup_length}, "
-             "{seed}, "
-             "{forward_type}, "
-             "{nesterov}, "
-             "{no_bn_decay}, "
-             "{trainers}, "
-             "{lr}, "
-             "{batch_size}, "
-             "{conv_type}, "
-             "{bn_type}, "
-             "{nonlinearity}, "
-             "{act_a}, "
-             "{act_w}, "
-             "{delta}, "
-             "{enable_dampen}, "
-             "{track_momentum}, "
-             "{track_threshold}, "
-             "{dampen_weight}, "
-             "{enable_ags}\n"
-             ).format(now=now, **kwargs)
-        )
 
 
 if __name__ == "__main__":

--- a/model/modules/ovsw.py
+++ b/model/modules/ovsw.py
@@ -106,7 +106,7 @@ class OvSWConv2d(nn.Conv2d):
             # 3. 更新梯度
             self.weight.grad = grad
 
-            # uodate weight_prev
+            # update weight_prev
             self.weight_prev.data = self.weight.data.clone()
             return torch.mean(condition_track * 1.)
 

--- a/resnet18_resnet20_vggsmall.py
+++ b/resnet18_resnet20_vggsmall.py
@@ -1,49 +1,14 @@
-import os
-import random
+from utils.sweep import SweepConfig, run_sweep
 
-import torch
-
-run = print
-if torch.cuda.is_available():
-    run = os.system
-configs = ["./configs/smallscale/w1a1-ovsw-resnet18-cifar10.yaml",
-           "./configs/smallscale/w1a1-ovsw-resnet20-cifar10.yaml",
-           "./configs/smallscale/w1a1-ovsw-vgg-cifar10.yaml"]
-configs = [configs[-2], ]
-forward_type = "xnor"
-save_every = 1
-epochs = [300, 400, 500, 600]
-enable_ags = True
-enable_dampen = True
-dampen_weights = [0.0009, ]
-random.shuffle(dampen_weights)
-print(dampen_weights)
-
-seeds = [46, 47, 48, 49, 50]
-nums = len(seeds)
-deltas = [0.04, ]
-random.shuffle(deltas)
-print(deltas)
-for config in configs:
-    for epoch in epochs:
-        for dampen_weight in dampen_weights:
-            for delta in deltas:
-                if not torch.cuda.is_available():
-                    name = f'{forward_type}_{epoch}_{dampen_weight:.5f}_{delta:.5f}'
-                    path = os.path.join("../../runs", os.path.basename(config).replace('.yaml', ''), name)
-                    for seed in seeds:
-                        orders = (f"python main.py --config {config} --forward-type {forward_type} --name {name} \\"
-                                  f"--epochs {epoch} --delta {delta:.5f} --seed {seed} --enable_ags {enable_ags} \\"
-                                  f"--enable_dampen {enable_dampen} --dampen_weight {dampen_weight}")
-                        run(orders)
-                else:
-                    name = f'{forward_type}_{epoch}_{dampen_weight:.5f}_{delta:.5f}'
-                    path = os.path.join("./runs", os.path.basename(config).replace('.yaml', ''), name)
-                    os.makedirs(path, exist_ok=True)
-                    while len(os.listdir(path)) < nums + 3:
-                        index = max(len(os.listdir(path)) - 3, 0)
-                        seed = seeds[index]
-                        orders = (f"python main.py --config {config} --forward-type {forward_type} --name {name} \\"
-                                  f"--epochs {epoch} --delta {delta:.5f} --seed {seed} --enable_ags {enable_ags} \\"
-                                  f"--enable_dampen {enable_dampen} --dampen_weight {dampen_weight}")
-                        run(orders)
+if __name__ == "__main__":
+    run_sweep(
+        SweepConfig(
+            configs=[
+                "./configs/smallscale/w1a1-ovsw-resnet20-cifar10.yaml",
+            ],
+            epochs=[300, 400, 500, 600],
+            dampen_weights=[0.0009],
+            deltas=[0.04],
+            seeds=[46, 47, 48, 49, 50],
+        )
+    )

--- a/resnet18_resnet34_imagenet.py
+++ b/resnet18_resnet34_imagenet.py
@@ -1,56 +1,24 @@
-import os
-import random
+from utils.sweep import SweepConfig, run_sweep
 
-import torch
 
-run = print
-if torch.cuda.is_available():
-    run = os.system
-configs = ["./configs/largescale/w1a1-ovsw-resnet18-imagenet.yaml",
-           "./configs/largescale/w1a1-ovsw-resnet34-imagenet.yaml"]
-forward_type = "xnor"
-set = "ImageNet"
-save_every = 1
-epochs = [200, ]
-scaling_factor = False
-enable_ags = True
-enable_dampen = True
-dampen_weights = [0.00002, ]
-random.shuffle(dampen_weights)
-print(dampen_weights)
+def _imagenet_extra_args(config: str) -> str:
+    if "resnet18" in config:
+        return "--batch-size 512 --warmup_length 5"
+    return ""
 
-seeds = [42, ]
-nums = len(seeds)
-deltas = [0.01, ]
-random.shuffle(deltas)
-print(deltas)
 
-for config in configs:
-    for epoch in epochs:
-        for dampen_weight in dampen_weights:
-            for delta in deltas:
-                if not torch.cuda.is_available():
-                    name = f'{forward_type}_{epoch}_{dampen_weight:.5f}_{delta:.5f}'
-                    path = os.path.join("../../runs", os.path.basename(config).replace('.yaml', ''), name)
-                    for seed in seeds:
-                        orders = (f"python main.py --config {config} --forward-type {forward_type} --name {name} \\"
-                                  f"--epochs {epoch} --delta {delta:.5f} --seed {seed} --enable_ags {enable_ags} \\"
-                                  f"--enable_dampen {enable_dampen} --dampen_weight {dampen_weight} --set {set} \\"
-                                  f"--scaling_factor {scaling_factor}")
-                        if 'resnet18' in orders:
-                            orders += " --batch-size 512 --warmup_length 5"
-                        run(orders)
-                else:
-                    name = f'{forward_type}_{epoch}_{dampen_weight:.5f}_{delta:.5f}'
-                    path = os.path.join("./runs", os.path.basename(config).replace('.yaml', ''), name)
-                    os.makedirs(path, exist_ok=True)
-                    while len(os.listdir(path)) < nums + 3:
-                        index = max(len(os.listdir(path)) - 3, 0)
-                        seed = seeds[index]
-                        orders = (f"python main.py --config {config} --forward-type {forward_type} --name {name} \\"
-                                  f"--epochs {epoch} --delta {delta:.5f} --seed {seed} --enable_ags {enable_ags} \\"
-                                  f"--enable_dampen {enable_dampen} --dampen_weight {dampen_weight} --set {set}  \\"
-                                  f"--scaling_factor {scaling_factor}")
-                        if 'resnet18' in orders:
-                            orders += " --batch-size 512 --warmup_length 5"
-                        run(orders)
+if __name__ == "__main__":
+    run_sweep(
+        SweepConfig(
+            configs=[
+                "./configs/largescale/w1a1-ovsw-resnet18-imagenet.yaml",
+                "./configs/largescale/w1a1-ovsw-resnet34-imagenet.yaml",
+            ],
+            epochs=[200],
+            dampen_weights=[0.00002],
+            deltas=[0.01],
+            seeds=[42],
+            dataset="ImageNet",
+            extra_args_for_config=_imagenet_extra_args,
+        )
+    )

--- a/trainers/ovsw.py
+++ b/trainers/ovsw.py
@@ -1,11 +1,11 @@
 import time
 
-import torch
 import tqdm
 from torch.cuda.amp import autocast, GradScaler
 
 from utils.eval_utils import accuracy
 from utils.logging import AverageMeter, ProgressMeter
+from utils.ovsw_hooks import apply_ovsw_grad_updates
 
 __all__ = ["train", "validate"]
 
@@ -49,16 +49,7 @@ def train(train_loader, model, criterion, optimizer, epoch, args, writer):
         scaler.scale(loss).backward()
 
         scaler.unscale_(optimizer)
-
-        for module in model.modules():
-            if hasattr(module, 'adaptive_gradient_scale'):
-                ratio = module.adaptive_gradient_scale()
-                if i == 0 and args.enable_ags:
-                    args.logger.info(f"Epoch [{epoch}]: {ratio.detach().cpu().item():.5f}")
-            if hasattr(module, "conditional_dampening"):
-                ratio = module.conditional_dampening()
-                if i == 0 and args.enable_dampen and ratio is not None:
-                    args.logger.info(f"Epoch [{epoch}]: {ratio.detach().cpu().item() * 100:.5f}%")
+        apply_ovsw_grad_updates(model, args, epoch, log_epoch_metrics=(i == 0))
 
         scaler.step(optimizer)
         scaler.update()

--- a/utils/builder.py
+++ b/utils/builder.py
@@ -4,7 +4,6 @@ import torch
 import torch.nn as nn
 
 import model
-from args import args
 
 
 class Builder(object):
@@ -60,7 +59,7 @@ class Builder(object):
         return self.bn_layer(planes, affine=affine)
 
     def activation(self, **kwargs):
-        nonlinearity = args.nonlinearity.lower()
+        nonlinearity = self.args.nonlinearity.lower()
         name_to_func = {
             "relu": nn.ReLU(inplace=True),
             "gelu": nn.GELU(),
@@ -72,16 +71,15 @@ class Builder(object):
         return name_to_func[nonlinearity]
 
     def _init_conv(self, conv):
+        args = self.args
         nonlinearity = "leaky_relu"
         if args.init == "signed_constant":
-
             fan = nn.init._calculate_correct_fan(conv.weight, args.mode)
             gain = nn.init.calculate_gain(nonlinearity)
             std = gain / math.sqrt(fan)
             conv.weight.data = conv.weight.data.sign() * std
 
         elif args.init == "unsigned_constant":
-
             fan = nn.init._calculate_correct_fan(conv.weight, args.mode)
             gain = nn.init.calculate_gain(nonlinearity)
             std = gain / math.sqrt(fan)
@@ -97,13 +95,11 @@ class Builder(object):
         elif args.init == "xavier_normal":
             nn.init.xavier_normal_(conv.weight)
         elif args.init == "xavier_constant":
-
             fan_in, fan_out = nn.init._calculate_fan_in_and_fan_out(conv.weight)
             std = math.sqrt(2.0 / float(fan_in + fan_out))
             conv.weight.data = conv.weight.data.sign() * std
 
         elif args.init == "standard":
-
             nn.init.kaiming_uniform_(conv.weight, a=math.sqrt(5))
 
         else:

--- a/utils/function.py
+++ b/utils/function.py
@@ -147,15 +147,14 @@ def get_directories(args):
 
 
 def get_optimizer(args, model, logger):
-    for n, v in model.named_parameters():
-        if v.requires_grad:
-            logger.info(f"<DEBUG> gradient to {n}")
-
-        if not v.requires_grad:
-            logger.info(f"<DEBUG> no gradient to {n}")
+    parameters = list(model.named_parameters())
+    for name, param in parameters:
+        if param.requires_grad:
+            logger.info(f"<DEBUG> gradient to {name}")
+        else:
+            logger.info(f"<DEBUG> no gradient to {name}")
 
     if args.optimizer == "sgd":
-        parameters = list(model.named_parameters())
         bn_params = [v for n, v in parameters if len(v.shape) == 1 and v.requires_grad]
         rest_params = [v for n, v in parameters if len(v.shape) != 1 and v.requires_grad]
         optimizer = torch.optim.SGD(

--- a/utils/net_utils.py
+++ b/utils/net_utils.py
@@ -6,40 +6,26 @@ import torch
 
 
 def init_model(model, logger, args):
-    # 0. init logger
+    start_epoch = args.start_epoch
     for module in model.modules():
         if hasattr(module, "init_logger"):
             module.init_logger(logger=logger)
-
-    # 1. init forward type
-    for module in model.modules():
         if hasattr(module, "init_forward_type"):
             module.init_forward_type(forward_type=args.forward_type)
-
-    # 2. init act_a and act_w
-    for module in model.modules():
         if hasattr(module, "init_binary_activation_and_weight"):
             module.init_binary_activation_and_weight(act_a=args.act_a, act_w=args.act_w)
-
-    # 3. init enable_oscillation_dampen
-    for module in model.modules():
         if hasattr(module, "init_dampen"):
             module.init_dampen(args=args)
-
-    # 4. init adaptive_gradient_scale
-    for module in model.modules():
         if hasattr(module, "init_adaptive_gradient_scale"):
             module.init_adaptive_gradient_scale(args=args)
-
-    # 5. init scaling factor
-    for module in model.modules():
         if hasattr(module, "init_scaling_factor"):
             module.init_scaling_factor(scaling_factor=args.scaling_factor)
-
-    # 6. init epoch
-    for module in model.modules():
         if hasattr(module, "init_epoch"):
-            module.init_epoch(start_epoch=args.start_epoch, end_epoch=args.epochs, epoch_num=args.epochs)
+            module.init_epoch(
+                start_epoch=start_epoch,
+                end_epoch=args.epochs,
+                epoch_num=args.epochs,
+            )
 
 
 def disable_oscillation_dampen(model):

--- a/utils/ovsw_hooks.py
+++ b/utils/ovsw_hooks.py
@@ -1,0 +1,13 @@
+def apply_ovsw_grad_updates(model, args, epoch: int, log_epoch_metrics: bool = False) -> None:
+    """Apply OvSW adaptive gradient scaling and silent-weight dampening."""
+    for module in model.modules():
+        if hasattr(module, "adaptive_gradient_scale"):
+            ratio = module.adaptive_gradient_scale()
+            if log_epoch_metrics and args.enable_ags:
+                args.logger.info(f"Epoch [{epoch}]: {ratio.detach().cpu().item():.5f}")
+        if hasattr(module, "conditional_dampening"):
+            ratio = module.conditional_dampening()
+            if log_epoch_metrics and args.enable_dampen and ratio is not None:
+                args.logger.info(
+                    f"Epoch [{epoch}]: {ratio.detach().cpu().item() * 100:.5f}%"
+                )

--- a/utils/results.py
+++ b/utils/results.py
@@ -1,0 +1,91 @@
+import pathlib
+import time
+
+CSV_HEADER = (
+    "Date Finished, "
+    "Base Config, "
+    "Name, "
+    "Arch, "
+    "Set, "
+    "Current Val Top 1, "
+    "Current Val Top 5, "
+    "Best Val Top 1, "
+    "Best Val Top 5, "
+    "Best Train Top 1, "
+    "Best Train Top 5, "
+    "Device Target, "
+    "Epochs, "
+    "Optimizer, "
+    "Weight Decay, "
+    "Warmup Length, "
+    "Seed, "
+    "Forward Type, "
+    "Nesterov, "
+    "NoBnDecay, "
+    "Trainers, "
+    "LearningRate, "
+    "BatchSize, "
+    "ConvType, "
+    "BnType, "
+    "Nonlinearity, "
+    "ActActivation, "
+    "ActWeight, "
+    "Delta, "
+    "Enable Dampening, "
+    "Track Momentum, "
+    "Track Threshold, "
+    "Dampen Weight, "
+    "Enable Ags\n"
+)
+
+CSV_ROW_TEMPLATE = (
+    "{now}, "
+    "{base_config}, "
+    "{name}, "
+    "{arch}, "
+    "{set}, "
+    "{curr_acc1:.02f}, "
+    "{curr_acc5:.02f}, "
+    "{best_acc1:.02f}, "
+    "{best_acc5:.02f}, "
+    "{best_train_acc1:.02f}, "
+    "{best_train_acc5:.02f}, "
+    "{device_target}, "
+    "{epochs}, "
+    "{optimizer}, "
+    "{weight_decay}, "
+    "{warmup_length}, "
+    "{seed}, "
+    "{forward_type}, "
+    "{nesterov}, "
+    "{no_bn_decay}, "
+    "{trainers}, "
+    "{lr}, "
+    "{batch_size}, "
+    "{conv_type}, "
+    "{bn_type}, "
+    "{nonlinearity}, "
+    "{act_a}, "
+    "{act_w}, "
+    "{delta}, "
+    "{enable_dampen}, "
+    "{track_momentum}, "
+    "{track_threshold}, "
+    "{dampen_weight}, "
+    "{enable_ags}\n"
+)
+
+
+def write_result_to_csv(arch, **kwargs):
+    """Append a training run summary to runs/train_{arch}_from_scratch.csv."""
+    results = pathlib.Path("runs") / f"train_{arch}_from_scratch.csv"
+    if not results.exists():
+        results.write_text(CSV_HEADER)
+
+    now = time.strftime("%m-%d-%y_%H:%M:%S")
+    with open(results, "a+", encoding="utf-8") as f:
+        f.write(CSV_ROW_TEMPLATE.format(now=now, arch=arch, **kwargs))
+
+
+# Backward-compatible alias for the original misspelled function name.
+write_result_to_csv_scrach = write_result_to_csv

--- a/utils/schedulers.py
+++ b/utils/schedulers.py
@@ -55,7 +55,7 @@ def multistep_lr(optimizer, args, **kwargs):
     """Sets the learning rate to the initial LR decayed by 10 every 30 epochs"""
 
     def _lr_adjuster(epoch, iteration):
-        lr = args.lr * (args.lr_gamma ** (epoch // args.lr_adjust))
+        lr = args.lr * (args.multistep_lr_gamma ** (epoch // args.multistep_lr_adjust))
 
         assign_learning_rate(optimizer, lr)
 

--- a/utils/seed.py
+++ b/utils/seed.py
@@ -1,0 +1,15 @@
+import os
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed: int) -> None:
+    """Set random seeds for reproducible training."""
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)

--- a/utils/sweep.py
+++ b/utils/sweep.py
@@ -1,0 +1,135 @@
+import os
+import random
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, List, Optional
+
+
+@dataclass
+class SweepConfig:
+    configs: List[str]
+    forward_type: str = "xnor"
+    epochs: List[int] = field(default_factory=lambda: [200])
+    dampen_weights: List[float] = field(default_factory=lambda: [2e-5])
+    deltas: List[float] = field(default_factory=lambda: [0.01])
+    seeds: List[int] = field(default_factory=lambda: [42])
+    enable_ags: bool = True
+    enable_dampen: bool = True
+    scaling_factor: bool = False
+    dataset: Optional[str] = None
+    extra_args: str = ""
+    extra_args_for_config: Optional[Callable[[str], str]] = None
+    shuffle_hyperparams: bool = True
+
+
+def _build_command(
+    config: str,
+    forward_type: str,
+    name: str,
+    epoch: int,
+    delta: float,
+    seed: int,
+    enable_ags: bool,
+    enable_dampen: bool,
+    dampen_weight: float,
+    scaling_factor: bool,
+    dataset: Optional[str],
+    extra_args: str,
+) -> str:
+    parts = [
+        f"python main.py --config {config}",
+        f"--forward-type {forward_type}",
+        f"--name {name}",
+        f"--epochs {epoch}",
+        f"--delta {delta:.5f}",
+        f"--seed {seed}",
+        f"--enable_ags {enable_ags}",
+        f"--enable_dampen {enable_dampen}",
+        f"--dampen_weight {dampen_weight}",
+        f"--scaling_factor {scaling_factor}",
+    ]
+    if dataset is not None:
+        parts.append(f"--set {dataset}")
+    if extra_args:
+        parts.append(extra_args.strip())
+    return " ".join(parts)
+
+
+def _run_dir_for_config(config: str, name: str, cuda_available: bool) -> str:
+    base = "./runs" if cuda_available else "../../runs"
+    config_name = os.path.basename(config).replace(".yaml", "")
+    return os.path.join(base, config_name, name)
+
+
+def run_sweep(
+    sweep: SweepConfig,
+    runner: Optional[Callable[[str], int]] = None,
+    cuda_available: Optional[bool] = None,
+) -> None:
+    """Run a hyperparameter sweep by invoking main.py for each configuration."""
+    if cuda_available is None:
+        import torch
+
+        cuda_available = torch.cuda.is_available()
+
+    if runner is None:
+        runner = os.system if cuda_available else print
+
+    dampen_weights = list(sweep.dampen_weights)
+    deltas = list(sweep.deltas)
+    if sweep.shuffle_hyperparams:
+        random.shuffle(dampen_weights)
+        random.shuffle(deltas)
+
+    print(dampen_weights)
+    print(deltas)
+
+    for config in sweep.configs:
+        config_extra_args = sweep.extra_args
+        if sweep.extra_args_for_config is not None:
+            config_extra_args = f"{config_extra_args} {sweep.extra_args_for_config(config)}".strip()
+
+        for epoch in sweep.epochs:
+            for dampen_weight in dampen_weights:
+                for delta in deltas:
+                    name = f"{sweep.forward_type}_{epoch}_{dampen_weight:.5f}_{delta:.5f}"
+                    path = _run_dir_for_config(config, name, cuda_available)
+
+                    if not cuda_available:
+                        for seed in sweep.seeds:
+                            command = _build_command(
+                                config=config,
+                                forward_type=sweep.forward_type,
+                                name=name,
+                                epoch=epoch,
+                                delta=delta,
+                                seed=seed,
+                                enable_ags=sweep.enable_ags,
+                                enable_dampen=sweep.enable_dampen,
+                                dampen_weight=dampen_weight,
+                                scaling_factor=sweep.scaling_factor,
+                                dataset=sweep.dataset,
+                                extra_args=config_extra_args,
+                            )
+                            runner(command)
+                        continue
+
+                    os.makedirs(path, exist_ok=True)
+                    target_runs = len(sweep.seeds) + 3
+                    while len(os.listdir(path)) < target_runs:
+                        index = max(len(os.listdir(path)) - 3, 0)
+                        seed = sweep.seeds[index]
+                        command = _build_command(
+                            config=config,
+                            forward_type=sweep.forward_type,
+                            name=name,
+                            epoch=epoch,
+                            delta=delta,
+                            seed=seed,
+                            enable_ags=sweep.enable_ags,
+                            enable_dampen=sweep.enable_dampen,
+                            dampen_weight=dampen_weight,
+                            scaling_factor=sweep.scaling_factor,
+                            dataset=sweep.dataset,
+                            extra_args=config_extra_args,
+                        )
+                        runner(command)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR refactors the OvSW (ECCV 2024) training codebase to reduce duplication and improve maintainability without changing core training behavior.

## Changes

### New shared utilities
- `utils/results.py` — training result CSV export (replaces inline logic in `main.py`)
- `utils/sweep.py` — shared hyperparameter sweep runner used by both sweep entry scripts
- `utils/seed.py` — centralized random seed setup
- `utils/ovsw_hooks.py` — OvSW gradient scaling / dampening hooks extracted from the trainer

### Simplified modules
- `main.py` — slimmer entry point; delegates CSV writing and seed setup
- `utils/net_utils.py` — single-pass model initialization instead of six separate loops
- `utils/builder.py` — uses `self.args` instead of importing global `args`
- `trainers/ovsw.py` — cleaner training loop via shared OvSW hooks
- `resnet18_resnet34_imagenet.py` / `resnet18_resnet20_vggsmall.py` — thin wrappers around `SweepConfig`

### Bug fixes
- `utils/schedulers.py` — multistep LR now uses correct argparse fields (`multistep_lr_adjust`, `multistep_lr_gamma`)
- Minor typo fixes in `args.py` and `model/modules/ovsw.py`

## Behavior notes
- Sweep scripts preserve original hyperparameter grids and ResNet18-only `--batch-size 512 --warmup_length 5` behavior
- CSV output filename corrected from `from_scrach` to `from_scratch` (alias kept for compatibility)

## Testing
- `python3 -m py_compile` on all modified Python files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f28c1-c94b-77a4-9b7a-72738ebbca4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f28c1-c94b-77a4-9b7a-72738ebbca4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

